### PR TITLE
 \newcommand{\ASU} wrong

### DIFF
--- a/institutionAliases.tex
+++ b/institutionAliases.tex
@@ -17,7 +17,8 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \newcommand{\Amherst}{University of Massachusetts, Amherst, MA 01003 USA}
-\newcommand{\ASU}{University of Arizona, Tucson, AZ  85721}
+\newcommand{\UA}{Department of Astronomy/Steward Observatory, University of Arizona, Tucson, AZ  85721}
+\newcommand{\ASU}{Arizona State University, Tempe, AZ  85287}
 \newcommand{\BNL}{Brookhaven National Laboratory, Upton, NY 11973}
 \newcommand{\Brown}{Brown University, Providence, RI 02912}
 \newcommand{\Bub}{Boston University, Boston, MA 02215}


### PR DESCRIPTION
The \newcommand{\ASU} command links to the wrong university.  ASU is Arizona State University in Tempe, and the University of Arizona is the one with Steward Observatory). These commands should read:

\newcommand{\ASU}{Arizona State University, Tempe, AZ  85287}
\newcommand{UA}{Department of Astronomy/Steward Observatory, University of Arizona, 933 N Cherry Ave, Tucson, AZ  85716}

Thank you very much!  Brenda